### PR TITLE
DevToolsHelper: Add `ValueAsJson` property

### DIFF
--- a/src/Components/WebAssembly/DebugProxy/src/MonoDebugProxy/ws-proxy/DevToolsHelper.cs
+++ b/src/Components/WebAssembly/DebugProxy/src/MonoDebugProxy/ws-proxy/DevToolsHelper.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Net;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace WebAssembly.Net.Debugging {
 
@@ -65,6 +66,19 @@ namespace WebAssembly.Net.Debugging {
 	internal class DotnetObjectId {
 		public string Scheme { get; }
 		public string Value { get; }
+
+		JObject value_json;
+		public JObject ValueAsJson {
+			get {
+				if (value_json == null) {
+					try {
+						value_json = JObject.Parse (Value);
+					} catch (JsonReaderException) {}
+				}
+
+				return value_json;
+			}
+		}
 
 		public static bool TryParse (JToken jToken, out DotnetObjectId objectId)
 			=> TryParse (jToken?.Value<string>(), out objectId);


### PR DESCRIPTION
- just sync'ing up with what mono has. This property gets used by
debugger tests
